### PR TITLE
Support AVRO logical types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
   <packaging>jar</packaging>
 
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <junit.version>5.8.2</junit.version>
     <test.containers.version>1.17.5</test.containers.version>
   </properties>

--- a/src/main/java/io/kafbat/ui/serde/glue/JsonAvroConversion.java
+++ b/src/main/java/io/kafbat/ui/serde/glue/JsonAvroConversion.java
@@ -1,5 +1,7 @@
 package io.kafbat.ui.serde.glue;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -37,10 +39,20 @@ import org.apache.avro.generic.GenericData;
  */
 public class JsonAvroConversion {
 
-  private static final JsonMapper MAPPER = new JsonMapper();
+  private static final JsonMapper MAPPER = JsonMapper.builder()
+      .enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN)
+      .build();
   private static final Schema NULL_SCHEMA = Schema.create(Schema.Type.NULL);
 
   private JsonAvroConversion() {
+  }
+
+  public static String toJsonString(Object obj, Schema avroSchema) {
+    try {
+      return MAPPER.writeValueAsString(convertAvroToJson(obj, avroSchema));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /**
@@ -183,6 +195,7 @@ public class JsonAvroConversion {
       } else {
         return new TextNode(obj.toString());
       }
+      decimal = decimal.stripTrailingZeros();
       return new DecimalNode(decimal);
     }),
 

--- a/src/main/java/io/kafbat/ui/serde/glue/JsonAvroConversion.java
+++ b/src/main/java/io/kafbat/ui/serde/glue/JsonAvroConversion.java
@@ -1,0 +1,277 @@
+package io.kafbat.ui.serde.glue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.DecimalNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.FloatNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+
+/**
+ * Utility class for converting Avro to JSON with proper logical type handling.
+ * Based on kafbat/kafka-ui JsonAvroConversion implementation.
+ * 
+ * @see <a href="https://github.com/kafbat/kafka-ui/blob/main/api/src/main/java/io/kafbat/ui/util/jsonschema/JsonAvroConversion.java">Original implementation</a>
+ */
+public class JsonAvroConversion {
+
+  private static final JsonMapper MAPPER = new JsonMapper();
+  private static final Schema NULL_SCHEMA = Schema.create(Schema.Type.NULL);
+
+  private JsonAvroConversion() {
+  }
+
+  /**
+   * Converts Avro object to JsonNode with proper logical type handling.
+   */
+  @SuppressWarnings("unchecked")
+  public static JsonNode convertAvroToJson(Object obj, Schema avroSchema) {
+    if (obj == null) {
+      return NullNode.getInstance();
+    }
+    return switch (avroSchema.getType()) {
+      case RECORD -> {
+        var rec = (GenericData.Record) obj;
+        ObjectNode node = MAPPER.createObjectNode();
+        for (Schema.Field field : avroSchema.getFields()) {
+          var fieldVal = rec.get(field.name());
+          if (fieldVal != null) {
+            node.set(field.name(), convertAvroToJson(fieldVal, field.schema()));
+          }
+        }
+        yield node;
+      }
+      case MAP -> {
+        ObjectNode node = MAPPER.createObjectNode();
+        ((Map<?, ?>) obj).forEach((k, v) -> node.set(k.toString(), convertAvroToJson(v, avroSchema.getValueType())));
+        yield node;
+      }
+      case ARRAY -> {
+        var list = (List<Object>) obj;
+        ArrayNode node = MAPPER.createArrayNode();
+        list.forEach(e -> node.add(convertAvroToJson(e, avroSchema.getElementType())));
+        yield node;
+      }
+      case ENUM -> new TextNode(obj.toString());
+      case UNION -> {
+        int unionIdx = GenericData.get().resolveUnion(avroSchema, obj);
+        Schema selectedType = avroSchema.getTypes().get(unionIdx);
+        
+        // For nullable unions [null, type], flatten - return value directly
+        if (avroSchema.getTypes().size() == 2 && avroSchema.getTypes().contains(NULL_SCHEMA)) {
+          yield convertAvroToJson(obj, selectedType);
+        }
+        
+        // For complex unions, wrap with type name
+        ObjectNode node = MAPPER.createObjectNode();
+        node.set(
+            selectUnionTypeFieldName(avroSchema, selectedType, unionIdx),
+            convertAvroToJson(obj, selectedType)
+        );
+        yield node;
+      }
+      case STRING -> {
+        if (isLogicalType(avroSchema)) {
+          yield processLogicalType(obj, avroSchema);
+        }
+        yield new TextNode(obj.toString());
+      }
+      case LONG -> {
+        if (isLogicalType(avroSchema)) {
+          yield processLogicalType(obj, avroSchema);
+        }
+        yield new LongNode((Long) obj);
+      }
+      case INT -> {
+        if (isLogicalType(avroSchema)) {
+          yield processLogicalType(obj, avroSchema);
+        }
+        yield new IntNode((Integer) obj);
+      }
+      case FLOAT -> new FloatNode((Float) obj);
+      case DOUBLE -> new DoubleNode((Double) obj);
+      case BOOLEAN -> BooleanNode.valueOf((Boolean) obj);
+      case NULL -> NullNode.getInstance();
+      case BYTES -> {
+        if (isLogicalType(avroSchema)) {
+          yield processLogicalType(obj, avroSchema);
+        }
+        ByteBuffer bytes = (ByteBuffer) obj;
+        yield new TextNode(new String(bytes.array(), StandardCharsets.ISO_8859_1));
+      }
+      case FIXED -> {
+        if (isLogicalType(avroSchema)) {
+          yield processLogicalType(obj, avroSchema);
+        }
+        var fixed = (GenericData.Fixed) obj;
+        yield new TextNode(new String(fixed.bytes(), StandardCharsets.ISO_8859_1));
+      }
+    };
+  }
+
+  private static String selectUnionTypeFieldName(Schema unionSchema,
+                                                 Schema chosenType,
+                                                 int chosenTypeIdx) {
+    var types = unionSchema.getTypes();
+    if (types.size() == 2 && types.contains(NULL_SCHEMA)) {
+      return chosenType.getName();
+    }
+    for (int i = 0; i < types.size(); i++) {
+      if (i != chosenTypeIdx && chosenType.getName().equals(types.get(i).getName())) {
+        return chosenType.getFullName();
+      }
+    }
+    return chosenType.getName();
+  }
+
+  private static JsonNode processLogicalType(Object obj, Schema schema) {
+    return findConversion(schema)
+        .map(c -> c.conversion.apply(obj, schema))
+        .orElseGet(() -> new TextNode(obj.toString()));
+  }
+
+  private static Optional<LogicalTypeConversion> findConversion(Schema schema) {
+    String logicalTypeName = schema.getLogicalType().getName();
+    return Stream.of(LogicalTypeConversion.values())
+        .filter(t -> t.name.equalsIgnoreCase(logicalTypeName))
+        .findFirst();
+  }
+
+  private static boolean isLogicalType(Schema schema) {
+    return schema.getLogicalType() != null;
+  }
+
+  enum LogicalTypeConversion {
+    UUID("uuid", (obj, schema) -> new TextNode(obj.toString())),
+
+    DECIMAL("decimal", (obj, schema) -> {
+      BigDecimal decimal;
+      if (obj instanceof BigDecimal) {
+        decimal = (BigDecimal) obj;
+      } else if (obj instanceof ByteBuffer) {
+        ByteBuffer buffer = (ByteBuffer) obj;
+        byte[] bytes = new byte[buffer.remaining()];
+        buffer.duplicate().get(bytes);
+        int scale = (Integer) schema.getObjectProp("scale");
+        decimal = new BigDecimal(new java.math.BigInteger(bytes), scale);
+      } else if (obj instanceof GenericData.Fixed) {
+        byte[] bytes = ((GenericData.Fixed) obj).bytes();
+        int scale = (Integer) schema.getObjectProp("scale");
+        decimal = new BigDecimal(new java.math.BigInteger(bytes), scale);
+      } else {
+        return new TextNode(obj.toString());
+      }
+      return new DecimalNode(decimal);
+    }),
+
+    DATE("date", (obj, schema) -> {
+      if (obj instanceof LocalDate) {
+        return new TextNode(obj.toString());
+      }
+      if (obj instanceof Integer) {
+        return new TextNode(LocalDate.ofEpochDay((Integer) obj).toString());
+      }
+      return new TextNode(obj.toString());
+    }),
+
+    TIME_MILLIS("time-millis", (obj, schema) -> {
+      if (obj instanceof LocalTime) {
+        return new TextNode(obj.toString());
+      }
+      if (obj instanceof Integer) {
+        return new TextNode(
+            LocalTime.ofNanoOfDay(TimeUnit.MILLISECONDS.toNanos((Integer) obj)).toString());
+      }
+      return new TextNode(obj.toString());
+    }),
+
+    TIME_MICROS("time-micros", (obj, schema) -> {
+      if (obj instanceof LocalTime) {
+        return new TextNode(obj.toString());
+      }
+      if (obj instanceof Long) {
+        return new TextNode(
+            LocalTime.ofNanoOfDay(TimeUnit.MICROSECONDS.toNanos((Long) obj)).toString());
+      }
+      return new TextNode(obj.toString());
+    }),
+
+    TIMESTAMP_MILLIS("timestamp-millis", (obj, schema) -> {
+      if (obj instanceof Instant) {
+        return new TextNode(obj.toString());
+      }
+      if (obj instanceof Long) {
+        return new TextNode(Instant.ofEpochMilli((Long) obj).toString());
+      }
+      return new TextNode(obj.toString());
+    }),
+
+    TIMESTAMP_MICROS("timestamp-micros", (obj, schema) -> {
+      if (obj instanceof Instant) {
+        return new TextNode(obj.toString());
+      }
+      if (obj instanceof Long) {
+        long microsFromEpoch = (Long) obj;
+        long epochSeconds = microsFromEpoch / 1_000_000L;
+        long nanoAdjustment = (microsFromEpoch % 1_000_000L) * 1_000L;
+        return new TextNode(Instant.ofEpochSecond(epochSeconds, nanoAdjustment).toString());
+      }
+      return new TextNode(obj.toString());
+    }),
+
+    LOCAL_TIMESTAMP_MILLIS("local-timestamp-millis", (obj, schema) -> {
+      if (obj instanceof LocalDateTime) {
+        return new TextNode(obj.toString());
+      }
+      if (obj instanceof Long) {
+        Instant instant = Instant.ofEpochMilli((Long) obj);
+        return new TextNode(LocalDateTime.ofInstant(instant, ZoneOffset.UTC).toString());
+      }
+      return new TextNode(obj.toString());
+    }),
+
+    LOCAL_TIMESTAMP_MICROS("local-timestamp-micros", (obj, schema) -> {
+      if (obj instanceof LocalDateTime) {
+        return new TextNode(obj.toString());
+      }
+      if (obj instanceof Long) {
+        long microsFromEpoch = (Long) obj;
+        long epochSeconds = microsFromEpoch / 1_000_000L;
+        long nanoAdjustment = (microsFromEpoch % 1_000_000L) * 1_000L;
+        Instant instant = Instant.ofEpochSecond(epochSeconds, nanoAdjustment);
+        return new TextNode(LocalDateTime.ofInstant(instant, ZoneOffset.UTC).toString());
+      }
+      return new TextNode(obj.toString());
+    });
+
+    private final String name;
+    private final BiFunction<Object, Schema, JsonNode> conversion;
+
+    LogicalTypeConversion(String name, BiFunction<Object, Schema, JsonNode> conversion) {
+      this.name = name;
+      this.conversion = conversion;
+    }
+  }
+}

--- a/src/main/java/io/kafbat/ui/serde/glue/JsonUtil.java
+++ b/src/main/java/io/kafbat/ui/serde/glue/JsonUtil.java
@@ -18,7 +18,7 @@ class JsonUtil {
   }
 
   static String avroRecordToJson(GenericRecord record) {
-    return JsonAvroConversion.convertAvroToJson(record, record.getSchema()).toString();
+    return JsonAvroConversion.toJsonString(record, record.getSchema());
   }
 
   static String protoMsgToJson(DynamicMessage msg) {

--- a/src/main/java/io/kafbat/ui/serde/glue/JsonUtil.java
+++ b/src/main/java/io/kafbat/ui/serde/glue/JsonUtil.java
@@ -4,18 +4,13 @@ import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
-import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.DecoderFactory;
-import org.apache.avro.io.EncoderFactory;
-import org.apache.avro.io.JsonEncoder;
 
 class JsonUtil {
 
@@ -23,16 +18,7 @@ class JsonUtil {
   }
 
   static String avroRecordToJson(GenericRecord record) {
-    try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-      Schema schema = record.getSchema();
-      JsonEncoder encoder = EncoderFactory.get().jsonEncoder(schema, out);
-      DatumWriter<Object> writer = new GenericDatumWriter<>(schema);
-      writer.write(record, encoder);
-      encoder.flush();
-      return out.toString();
-    } catch (IOException ioe) {
-      throw new RuntimeException(ioe);
-    }
+    return JsonAvroConversion.convertAvroToJson(record, record.getSchema()).toString();
   }
 
   static String protoMsgToJson(DynamicMessage msg) {

--- a/src/test/java/io/kafbat/ui/serde/glue/JsonAvroConversionTest.java
+++ b/src/test/java/io/kafbat/ui/serde/glue/JsonAvroConversionTest.java
@@ -1,0 +1,293 @@
+package io.kafbat.ui.serde.glue;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.junit.jupiter.api.Test;
+
+class JsonAvroConversionTest {
+
+  @Test
+  void testDecimalFormatting() {
+    var schema = new Schema.Parser().parse(
+        """
+            {
+              "type": "record",
+              "name": "TestDecimalRecord",
+              "fields": [
+                {
+                  "name": "amount",
+                  "type": { "type": "bytes", "logicalType": "decimal", "precision": 20, "scale": 10 }
+                },
+                {
+                  "name": "zero_amount",
+                  "type": { "type": "bytes", "logicalType": "decimal", "precision": 20, "scale": 10 }
+                },
+                {
+                  "name": "whole_number",
+                  "type": { "type": "bytes", "logicalType": "decimal", "precision": 10, "scale": 2 }
+                }
+              ]
+            }
+            """);
+
+    var record = new GenericRecordBuilder(schema)
+        .set("amount", new BigDecimal("1368.5000000000"))
+        .set("zero_amount", new BigDecimal("0.0000000000"))
+        .set("whole_number", new BigDecimal("42.00"))
+        .build();
+
+    String json = JsonUtil.avroRecordToJson(record);
+
+    // Verify decimals are output as numbers (not strings or binary)
+    assertTrue(json.contains("\"amount\":1368.5"),
+        "Decimal should be formatted as number: " + json);
+
+    assertTrue(json.contains("\"zero_amount\":0"),
+        "Zero decimal should be formatted as number: " + json);
+
+    assertTrue(json.contains("\"whole_number\":42"),
+        "Whole number decimal should be formatted as number: " + json);
+  }
+
+  @Test
+  void testNullableUnionFlattening() {
+    var schema = new Schema.Parser().parse(
+        """
+            {
+              "type": "record",
+              "name": "TestNullableRecord",
+              "fields": [
+                {
+                  "name": "nullable_int",
+                  "default": null,
+                  "type": ["null", "int"]
+                },
+                {
+                  "name": "nullable_string",
+                  "default": null,
+                  "type": ["null", "string"]
+                },
+                {
+                  "name": "nullable_null",
+                  "default": null,
+                  "type": ["null", "long"]
+                }
+              ]
+            }
+            """);
+
+    var record = new GenericRecordBuilder(schema)
+        .set("nullable_int", 42)
+        .set("nullable_string", "hello")
+        .set("nullable_null", null)
+        .build();
+
+    String json = JsonUtil.avroRecordToJson(record);
+
+    // Verify nullable int is flattened (not wrapped in {"int": 42})
+    assertTrue(json.contains("\"nullable_int\":42"),
+        "Nullable int should be flattened to direct value: " + json);
+    assertFalse(json.contains("\"int\":42"),
+        "Nullable int should not be wrapped with type name: " + json);
+
+    // Verify nullable string is flattened
+    assertTrue(json.contains("\"nullable_string\":\"hello\""),
+        "Nullable string should be flattened to direct value: " + json);
+    assertFalse(json.contains("\"string\":\"hello\""),
+        "Nullable string should not be wrapped with type name: " + json);
+
+    // Verify null value is not present in output (nulls are omitted)
+    assertFalse(json.contains("nullable_null"),
+        "Null values should be omitted from output: " + json);
+  }
+
+  @Test
+  void testComplexUnionNotFlattened() {
+    // Complex unions (more than 2 types, or 2 non-null types) should still be wrapped
+    var schema = new Schema.Parser().parse(
+        """
+            {
+              "type": "record",
+              "name": "TestComplexUnionRecord",
+              "fields": [
+                {
+                  "name": "multi_type",
+                  "type": ["null", "int", "string"]
+                }
+              ]
+            }
+            """);
+
+    var record = new GenericRecordBuilder(schema)
+        .set("multi_type", 42)
+        .build();
+
+    String json = JsonUtil.avroRecordToJson(record);
+
+    // Complex unions should still be wrapped with type name
+    assertTrue(json.contains("\"int\":42"),
+        "Complex union should be wrapped with type name: " + json);
+  }
+
+  @Test
+  void testAvroLogicalTypesJsonConversion() {
+    // Schema with multiple logical types
+    var schema = new Schema.Parser().parse(
+        """
+            {
+              "type": "record",
+              "name": "TestLogicalTypesRecord",
+              "fields": [
+                {
+                  "name": "lt_date",
+                  "type": { "type": "int", "logicalType": "date" }
+                },
+                {
+                  "name": "lt_uuid",
+                  "type": { "type": "string", "logicalType": "uuid" }
+                },
+                {
+                  "name": "lt_decimal",
+                  "type": { "type": "bytes", "logicalType": "decimal", "precision": 10, "scale": 2 }
+                },
+                {
+                  "name": "lt_time_millis",
+                  "type": { "type": "int", "logicalType": "time-millis" }
+                },
+                {
+                  "name": "lt_time_micros",
+                  "type": { "type": "long", "logicalType": "time-micros" }
+                },
+                {
+                  "name": "lt_timestamp_millis",
+                  "type": { "type": "long", "logicalType": "timestamp-millis" }
+                },
+                {
+                  "name": "lt_timestamp_micros",
+                  "type": { "type": "long", "logicalType": "timestamp-micros" }
+                },
+                {
+                  "name": "lt_local_timestamp_millis",
+                  "type": { "type": "long", "logicalType": "local-timestamp-millis" }
+                },
+                {
+                  "name": "lt_local_timestamp_micros",
+                  "type": { "type": "long", "logicalType": "local-timestamp-micros" }
+                }
+              ]
+            }
+            """);
+
+    // Test with already-converted logical type values (e.g., LocalDate, Instant)
+    var recordWithConvertedTypes = new GenericRecordBuilder(schema)
+        .set("lt_date", LocalDate.of(1991, 8, 14))
+        .set("lt_uuid", UUID.fromString("a37b75ca-097c-5d46-6119-f0637922e908"))
+        .set("lt_decimal", new BigDecimal("123.45"))
+        .set("lt_time_millis", LocalTime.of(10, 15, 30, 1_000_000)) // 10:15:30.001
+        .set("lt_time_micros", LocalTime.of(10, 15, 30, 123_456_000)) // 10:15:30.123456
+        .set("lt_timestamp_millis", Instant.parse("2007-12-03T10:15:30.123Z"))
+        .set("lt_timestamp_micros", Instant.parse("2007-12-13T10:15:30.123456Z"))
+        .set("lt_local_timestamp_millis", LocalDateTime.of(2017, 12, 3, 10, 15, 30, 123_000_000))
+        .set("lt_local_timestamp_micros", LocalDateTime.of(2017, 12, 13, 10, 15, 30, 123_456_000))
+        .build();
+
+    String json = JsonUtil.avroRecordToJson(recordWithConvertedTypes);
+
+    // Verify date is formatted as ISO date string, not as integer
+    assertTrue(json.contains("\"lt_date\":\"1991-08-14\""),
+        "Date should be formatted as ISO date string: " + json);
+
+    // Verify UUID is formatted as string
+    assertTrue(json.contains("\"lt_uuid\":\"a37b75ca-097c-5d46-6119-f0637922e908\""),
+        "UUID should be formatted as string: " + json);
+
+    // Verify decimal is formatted as number, not binary
+    assertTrue(json.contains("\"lt_decimal\":123.45"),
+        "Decimal should be formatted as number: " + json);
+
+    // Verify time-millis is formatted as ISO time string
+    assertTrue(json.contains("\"lt_time_millis\":\"10:15:30.001\""),
+        "Time-millis should be formatted as ISO time string: " + json);
+
+    // Verify time-micros is formatted as ISO time string
+    assertTrue(json.contains("\"lt_time_micros\":\"10:15:30.123456\""),
+        "Time-micros should be formatted as ISO time string: " + json);
+
+    // Verify timestamp-millis is formatted as ISO instant string
+    assertTrue(json.contains("\"lt_timestamp_millis\":\"2007-12-03T10:15:30.123Z\""),
+        "Timestamp-millis should be formatted as ISO instant string: " + json);
+
+    // Verify timestamp-micros is formatted as ISO instant string
+    assertTrue(json.contains("\"lt_timestamp_micros\":\"2007-12-13T10:15:30.123456Z\""),
+        "Timestamp-micros should be formatted as ISO instant string: " + json);
+
+    // Verify local-timestamp-millis is formatted as ISO local datetime string
+    assertTrue(json.contains("\"lt_local_timestamp_millis\":\"2017-12-03T10:15:30.123\""),
+        "Local-timestamp-millis should be formatted as ISO local datetime string: " + json);
+
+    // Verify local-timestamp-micros is formatted as ISO local datetime string
+    assertTrue(json.contains("\"lt_local_timestamp_micros\":\"2017-12-13T10:15:30.123456\""),
+        "Local-timestamp-micros should be formatted as ISO local datetime string: " + json);
+  }
+
+  @Test
+  void testAvroLogicalTypesWithRawValues() {
+    // Schema with logical types that may come as raw values
+    var schema = new Schema.Parser().parse(
+        """
+            {
+              "type": "record",
+              "name": "TestRawLogicalTypesRecord",
+              "fields": [
+                {
+                  "name": "lt_date",
+                  "type": { "type": "int", "logicalType": "date" }
+                },
+                {
+                  "name": "lt_time_millis",
+                  "type": { "type": "int", "logicalType": "time-millis" }
+                },
+                {
+                  "name": "lt_timestamp_millis",
+                  "type": { "type": "long", "logicalType": "timestamp-millis" }
+                }
+              ]
+            }
+            """);
+
+    // Test with raw numeric values (days since epoch, millis, etc.)
+    // Use Java to compute correct values to avoid calculation errors
+    LocalDate testDate = LocalDate.of(1991, 8, 14);
+    LocalTime testTime = LocalTime.of(10, 15, 30, 1_000_000);
+    Instant testInstant = Instant.parse("2007-12-03T10:15:30.123Z");
+
+    var recordWithRawValues = new GenericRecordBuilder(schema)
+        .set("lt_date", (int) testDate.toEpochDay())
+        .set("lt_time_millis", (int) (testTime.toNanoOfDay() / 1_000_000))
+        .set("lt_timestamp_millis", testInstant.toEpochMilli())
+        .build();
+
+    String json = JsonUtil.avroRecordToJson(recordWithRawValues);
+
+    // Verify date is converted from days since epoch to ISO date string
+    assertTrue(json.contains("\"lt_date\":\"1991-08-14\""),
+        "Date from raw int should be formatted as ISO date string: " + json);
+
+    // Verify time-millis is converted from millis to ISO time string
+    assertTrue(json.contains("\"lt_time_millis\":\"10:15:30.001\""),
+        "Time-millis from raw int should be formatted as ISO time string: " + json);
+
+    // Verify timestamp-millis is converted from millis to ISO instant string
+    assertTrue(json.contains("\"lt_timestamp_millis\":\"2007-12-03T10:15:30.123Z\""),
+        "Timestamp-millis from raw long should be formatted as ISO instant string: " + json);
+  }
+}

--- a/src/test/java/io/kafbat/ui/serde/glue/JsonAvroConversionTest.java
+++ b/src/test/java/io/kafbat/ui/serde/glue/JsonAvroConversionTest.java
@@ -34,6 +34,10 @@ class JsonAvroConversionTest {
                 {
                   "name": "whole_number",
                   "type": { "type": "bytes", "logicalType": "decimal", "precision": 10, "scale": 2 }
+                },
+                {
+                  "name": "round_number",
+                  "type": { "type": "bytes", "logicalType": "decimal", "precision": 10, "scale": 2 }
                 }
               ]
             }
@@ -43,6 +47,7 @@ class JsonAvroConversionTest {
         .set("amount", new BigDecimal("1368.5000000000"))
         .set("zero_amount", new BigDecimal("0.0000000000"))
         .set("whole_number", new BigDecimal("42.00"))
+        .set("round_number", new BigDecimal("10"))
         .build();
 
     String json = JsonUtil.avroRecordToJson(record);
@@ -56,6 +61,9 @@ class JsonAvroConversionTest {
 
     assertTrue(json.contains("\"whole_number\":42"),
         "Whole number decimal should be formatted as number: " + json);
+
+    assertTrue(json.contains("\"round_number\":10"),
+        "Round number decimal should be formatted as number: " + json);
   }
 
   @Test


### PR DESCRIPTION
Fixes #71 .

This PR implements AVRO logical types in JSON serialization. Unfortunately, AVRO's jsonEncoder does not support logical types (https://issues.apache.org/jira/browse/AVRO-1950).

In this PR I have created JsonAvroConversion type, which is heavily inspired by JsonAvroConversion from kafka-ui:
[kafbat/kafka-ui@main/api/src/main/java/io/kafbat/ui/util/jsonschema/JsonAvroConversion.java](https://github.com/kafbat/kafka-ui/blob/main/api/src/main/java/io/kafbat/ui/util/jsonschema/JsonAvroConversion.java)
